### PR TITLE
Fix compilation errors and improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Run C++ tests
       run: make test
 
-  esphome-validation:
-    name: ESPHome Validation
+  esphome-build:
+    name: ESPHome Build
     runs-on: ubuntu-latest
 
     steps:
@@ -47,3 +47,6 @@ jobs:
 
     - name: Validate ESPHome config
       run: uv run esphome config cosori-kettle.build.yaml
+
+    - name: Compile ESPHome firmware
+      run: uv run esphome compile cosori-kettle.build.yaml

--- a/components/cosori_kettle_ble/cosori_kettle_ble.h
+++ b/components/cosori_kettle_ble/cosori_kettle_ble.h
@@ -63,9 +63,9 @@ class CosoriKettleBLE : public esphome::ble_client::BLEClientNode, public Pollin
 
   // Registration key configuration (16-byte key for hello/reconnect)
   void set_registration_key(const std::array<uint8_t, 16> &key);
-  
+
   // Protocol version configuration (0 or 1)
-  void set_protocol_version(uint8_t version) { protocol_version_ = version; }
+  void set_protocol_version(uint8_t version);
 
   // Climate interface
   climate::ClimateTraits traits() override;

--- a/components/cosori_kettle_ble/cosori_kettle_state_log.h
+++ b/components/cosori_kettle_ble/cosori_kettle_state_log.h
@@ -1,13 +1,9 @@
 #pragma once
 
 // Logging macros that work both with and without ESPHome
-#ifdef ESPHOME_LOG_H_
-  // ESPHome is available, use its logging
-  #include "esphome/core/log.h"
-#else
-  // ESPHome not available, define our own logging macros
+// Only define these macros if they're not already defined
+#ifndef ESP_LOGE
   #include <cstdio>
-
   #define ESP_LOGE(tag, format, ...) printf("[E][%s] " format "\n", tag, ##__VA_ARGS__)
   #define ESP_LOGW(tag, format, ...) printf("[W][%s] " format "\n", tag, ##__VA_ARGS__)
   #define ESP_LOGI(tag, format, ...) printf("[I][%s] " format "\n", tag, ##__VA_ARGS__)


### PR DESCRIPTION
This commit fixes two compilation errors:

1. Logging macro redefinition: Changed the header guard in cosori_kettle_state_log.h to check if ESP_LOGE is already defined instead of checking for ESPHOME_LOG_H_. This prevents macro redefinition warnings when ESPHome headers are included.

2. Double definition of set_protocol_version: Removed the inline implementation in cosori_kettle_ble.h that was incorrectly referencing a non-existent protocol_version_ member variable. The proper implementation in the .cpp file is now used.

Additionally, the CI workflow has been improved to actually compile the ESPHome firmware instead of just validating the configuration. This ensures compilation errors are caught during CI runs.