### PR TITLE
Add configurable hold time number entity

### DIFF
--- a/custom_components/cosori_kettle_ble/__init__.py
+++ b/custom_components/cosori_kettle_ble/__init__.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,

--- a/custom_components/cosori_kettle_ble/climate.py
+++ b/custom_components/cosori_kettle_ble/climate.py
@@ -171,7 +171,9 @@ class CosoriKettleClimate(CoordinatorEntity[CosoriKettleCoordinator], ClimateEnt
                 temp_f = preset_temp  # Use the exact preset temperature
                 break
 
-        await self.coordinator.async_set_mode(mode, temp_f, 0)
+        await self.coordinator.async_set_mode(
+            mode, temp_f, self.coordinator.desired_hold_time_seconds
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -200,7 +202,9 @@ class CosoriKettleClimate(CoordinatorEntity[CosoriKettleCoordinator], ClimateEnt
             # MY_TEMP mode - use current my_temp or default
             temp_f = self.coordinator.data.get("my_temp", 212) if self.coordinator.data else 212
 
-        await self.coordinator.async_set_mode(kettle_mode, temp_f, 0)
+        await self.coordinator.async_set_mode(
+            kettle_mode, temp_f, self.coordinator.desired_hold_time_seconds
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self) -> None:

--- a/custom_components/cosori_kettle_ble/coordinator.py
+++ b/custom_components/cosori_kettle_ble/coordinator.py
@@ -78,6 +78,9 @@ class CosoriKettleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._model_number: str | None = None
         self._manufacturer: str | None = None
 
+        # User-configured desired hold time for next heating command
+        self._desired_hold_time_minutes: int = 0
+
         # BLE client (will be initialized in async_start)
         self._client: CosoriKettleBLEClient | None = None
 
@@ -446,6 +449,24 @@ class CosoriKettleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             raise UpdateFailed(
                                 f"Failed to reconnect after {MAX_RECONNECT_ATTEMPTS} attempts"
                             ) from err
+
+    @property
+    def desired_hold_time_minutes(self) -> int:
+        """Return the user-configured desired hold time in minutes."""
+        return self._desired_hold_time_minutes
+
+    @property
+    def desired_hold_time_seconds(self) -> int:
+        """Return the user-configured desired hold time in seconds."""
+        return self._desired_hold_time_minutes * 60
+
+    async def async_set_desired_hold_time(self, minutes: int) -> None:
+        """Set the desired hold time for next heating command.
+
+        Args:
+            minutes: Hold time in minutes (0 = disabled)
+        """
+        self._desired_hold_time_minutes = int(minutes)
 
     async def async_set_mode(self, mode: int, temp_f: int, hold_time: int) -> None:
         """Set heating mode."""

--- a/custom_components/cosori_kettle_ble/number.py
+++ b/custom_components/cosori_kettle_ble/number.py
@@ -1,0 +1,90 @@
+"""Number platform for Cosori Kettle BLE."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import CosoriKettleCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CosoriKettleNumberEntityDescription(NumberEntityDescription):
+    """Describes Cosori Kettle number entity."""
+
+    value_fn: Callable[[CosoriKettleCoordinator], float | None] | None = None
+    set_value_fn: Callable[[CosoriKettleCoordinator, float], Any] | None = None
+
+
+NUMBERS: tuple[CosoriKettleNumberEntityDescription, ...] = (
+    CosoriKettleNumberEntityDescription(
+        key="hold_time",
+        name="Hold Time",
+        native_min_value=0,
+        native_max_value=60,
+        native_step=1,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        mode=NumberMode.SLIDER,
+        value_fn=lambda coord: coord.desired_hold_time_minutes,
+        set_value_fn=lambda coord, val: coord.async_set_desired_hold_time(val),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    coordinator: CosoriKettleCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        CosoriKettleNumber(coordinator, description)
+        for description in NUMBERS
+    )
+
+
+class CosoriKettleNumber(CoordinatorEntity[CosoriKettleCoordinator], NumberEntity):
+    """Number entity for Cosori Kettle."""
+
+    entity_description: CosoriKettleNumberEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: CosoriKettleCoordinator,
+        description: CosoriKettleNumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.formatted_address}_{description.key}"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        if self.entity_description.value_fn:
+            return self.entity_description.value_fn(self.coordinator)
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        if self.entity_description.set_value_fn:
+            await self.entity_description.set_value_fn(self.coordinator, value)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -57,6 +57,7 @@ def mock_coordinator():
         "manufacturer": "Cosori",
         "model": "Smart Kettle",
     }
+    coordinator.desired_hold_time_seconds = 0
     coordinator.async_set_mode = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_stop_heating = AsyncMock()
@@ -310,6 +311,15 @@ class TestCosoriKettleClimateSetTemperature:
         mock_coordinator.async_set_mode.assert_called_once_with(MODE_BOIL, 212, 0)
 
 
+    @pytest.mark.asyncio
+    async def test_set_temperature_passes_hold_time(self, climate_entity, mock_coordinator):
+        """Test that hold time from coordinator is passed to async_set_mode."""
+        mock_coordinator.desired_hold_time_seconds = 1800
+        await climate_entity.async_set_temperature(temperature=175)
+
+        mock_coordinator.async_set_mode.assert_called_once_with(MODE_MY_TEMP, 175, 1800)
+
+
 class TestCosoriKettleClimateSetHVACMode:
     """Test async_set_hvac_mode method."""
 
@@ -406,6 +416,14 @@ class TestCosoriKettleClimateSetPresetMode:
         await climate_entity.async_set_preset_mode(PRESET_MY_TEMP)
 
         mock_coordinator.async_set_mode.assert_called_once_with(MODE_MY_TEMP, 212, 0)
+
+    @pytest.mark.asyncio
+    async def test_set_preset_mode_passes_hold_time(self, climate_entity, mock_coordinator):
+        """Test that hold time from coordinator is passed to async_set_mode."""
+        mock_coordinator.desired_hold_time_seconds = 600
+        await climate_entity.async_set_preset_mode(PRESET_BOIL)
+
+        mock_coordinator.async_set_mode.assert_called_once_with(MODE_BOIL, 212, 600)
 
     @pytest.mark.asyncio
     async def test_set_preset_mode_invalid_preset(self, climate_entity, mock_coordinator):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,128 @@
+"""Tests for the number platform module."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.cosori_kettle_ble.const import DOMAIN
+from custom_components.cosori_kettle_ble.number import (
+    CosoriKettleNumber,
+    NUMBERS,
+)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock coordinator."""
+    coordinator = AsyncMock()
+    coordinator.data = {}
+    coordinator.formatted_address = "test_entry_id"
+    coordinator.device_info = {
+        "identifiers": {(DOMAIN, "test_entry_id")},
+        "name": "Cosori Kettle",
+        "manufacturer": "Cosori",
+        "model": "Smart Kettle",
+    }
+    coordinator.desired_hold_time_minutes = 0
+    coordinator.async_set_desired_hold_time = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def hold_time_description():
+    """Return the hold time number entity description."""
+    return NUMBERS[0]
+
+
+@pytest.fixture
+def number_entity(mock_coordinator, hold_time_description):
+    """Create a number entity instance."""
+    return CosoriKettleNumber(mock_coordinator, hold_time_description)
+
+
+class TestCosoriKettleNumberInitialization:
+    """Test number entity initialization."""
+
+    def test_unique_id(self, number_entity):
+        """Test unique ID is set correctly."""
+        assert number_entity.unique_id == "test_entry_id_hold_time"
+
+    def test_has_entity_name(self, number_entity):
+        """Test has_entity_name is True."""
+        assert number_entity._attr_has_entity_name is True
+
+    def test_device_info(self, number_entity, mock_coordinator):
+        """Test device info matches coordinator."""
+        assert number_entity.device_info == mock_coordinator.device_info
+
+    def test_entity_description(self, number_entity, hold_time_description):
+        """Test entity description is set."""
+        assert number_entity.entity_description == hold_time_description
+
+
+class TestCosoriKettleNumberDescription:
+    """Test the hold time number entity description."""
+
+    def test_key(self, hold_time_description):
+        """Test description key."""
+        assert hold_time_description.key == "hold_time"
+
+    def test_name(self, hold_time_description):
+        """Test description name."""
+        assert hold_time_description.name == "Hold Time"
+
+    def test_min_value(self, hold_time_description):
+        """Test minimum value is 0."""
+        assert hold_time_description.native_min_value == 0
+
+    def test_max_value(self, hold_time_description):
+        """Test maximum value is 60 minutes."""
+        assert hold_time_description.native_max_value == 60
+
+    def test_step(self, hold_time_description):
+        """Test step is 1 minute."""
+        assert hold_time_description.native_step == 1
+
+    def test_unit(self, hold_time_description):
+        """Test unit is minutes."""
+        from homeassistant.const import UnitOfTime
+        assert hold_time_description.native_unit_of_measurement == UnitOfTime.MINUTES
+
+
+class TestCosoriKettleNumberValue:
+    """Test native_value property."""
+
+    def test_native_value_zero(self, number_entity, mock_coordinator):
+        """Test native value when hold time is 0."""
+        mock_coordinator.desired_hold_time_minutes = 0
+        assert number_entity.native_value == 0
+
+    def test_native_value_set(self, number_entity, mock_coordinator):
+        """Test native value when hold time is configured."""
+        mock_coordinator.desired_hold_time_minutes = 30
+        assert number_entity.native_value == 30
+
+    def test_native_value_max(self, number_entity, mock_coordinator):
+        """Test native value at maximum."""
+        mock_coordinator.desired_hold_time_minutes = 60
+        assert number_entity.native_value == 60
+
+
+class TestCosoriKettleNumberSetValue:
+    """Test async_set_native_value method."""
+
+    @pytest.mark.asyncio
+    async def test_set_value(self, number_entity, mock_coordinator):
+        """Test setting hold time value."""
+        await number_entity.async_set_native_value(30)
+        mock_coordinator.async_set_desired_hold_time.assert_called_once_with(30)
+
+    @pytest.mark.asyncio
+    async def test_set_value_zero_disables(self, number_entity, mock_coordinator):
+        """Test setting hold time to 0 disables hold."""
+        await number_entity.async_set_native_value(0)
+        mock_coordinator.async_set_desired_hold_time.assert_called_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_set_value_max(self, number_entity, mock_coordinator):
+        """Test setting hold time to max value."""
+        await number_entity.async_set_native_value(60)
+        mock_coordinator.async_set_desired_hold_time.assert_called_once_with(60)


### PR DESCRIPTION
## Summary
- Adds a **Hold Time** number entity (0–60 minute slider) so users can configure the kettle's keep-warm duration from the Home Assistant UI
- Updates the climate entity to pass the configured hold time to the BLE `send_set_mode` command instead of hardcoding `0`
- Adds coordinator properties (`desired_hold_time_minutes`, `desired_hold_time_seconds`) and `async_set_desired_hold_time()` to store the user's preference

## Motivation
The hold/keep-warm feature was fully implemented at the protocol and client level (`send_set_hold_time`, `send_set_mode` with `hold_time_seconds`) but was never wired up to any user-facing entity. The climate entity hardcoded `hold_time=0` in every `async_set_mode` call, meaning hold was always disabled.

## Changes
| File | Change |
|------|--------|
| `number.py` (new) | `NumberEntity` platform with "Hold Time" slider |
| `coordinator.py` | `_desired_hold_time_minutes` state, properties, and setter |
| `climate.py` | Reads `coordinator.desired_hold_time_seconds` instead of `0` |
| `__init__.py` | Added `Platform.NUMBER` to PLATFORMS |
| `tests/test_number.py` (new) | Tests for the number entity |
| `tests/test_climate.py` | Added mock fixture property + hold time passthrough tests |

## Test plan
- [x] All 306 existing + new tests pass (`uv run pytest tests/ -v`)
- [ ] Manual test: set hold time slider to 30 min, start heating, verify kettle enters hold mode after reaching target temperature
- [ ] Verify slider at 0 disables hold (same as previous behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)