### PR TITLE
fix(config_flow): fix pairing flow sending hello before register

### DIFF
--- a/custom_components/cosori_kettle_ble/config_flow.py
+++ b/custom_components/cosori_kettle_ble/config_flow.py
@@ -130,11 +130,18 @@ class CosoriKettleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if ble_device is None:
                 return self.async_abort(reason="device_not_found")
 
-            # Attempt pairing
+            # Attempt pairing -- must NOT use the context manager here, as
+            # __aenter__ calls connect() which sends hello before registration.
+            # Instead, pair() handles its own BLE connect + register + hello.
+            kettle = CosoriKettle(ble_device, registration_key)
             try:
-                async with CosoriKettle(ble_device, registration_key) as kettle:
-                    await kettle.pair()  # Sends register + hello
-
+                await kettle.pair()
+            except DeviceNotInPairingModeError:
+                errors["base"] = "device_not_in_pairing_mode"
+            except Exception as err:
+                _LOGGER.exception("Failed to pair device: %s", err)
+                errors["base"] = "pairing_failed"
+            else:
                 # Success! Create config entry
                 return self.async_create_entry(
                     title=self._discovery_info.name or "Cosori Kettle"
@@ -146,12 +153,8 @@ class CosoriKettleConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_REGISTRATION_KEY: registration_key.hex(),
                     },
                 )
-
-            except DeviceNotInPairingModeError:
-                errors["base"] = "device_not_in_pairing_mode"
-            except Exception as err:
-                _LOGGER.exception("Failed to pair device: %s", err)
-                errors["base"] = "pairing_failed"
+            finally:
+                await kettle.disconnect()
 
         return self.async_show_form(
             step_id="pair_device",

--- a/custom_components/cosori_kettle_ble/cosori_kettle/kettle.py
+++ b/custom_components/cosori_kettle_ble/cosori_kettle/kettle.py
@@ -120,15 +120,16 @@ class CosoriKettle:
     async def pair(self) -> None:
         """Pair with the kettle using registration key.
 
-        This should be called during initial setup when the device
-        is in pairing mode.
+        Handles the full connection sequence for initial pairing:
+        connects at the BLE level, registers the key, then sends hello.
+        Do NOT use the async context manager for pairing -- it calls
+        connect() which sends hello before registration.
 
         Raises:
             DeviceNotInPairingModeError: Device not in pairing mode
-            RuntimeError: Not connected to device
         """
         if not self.is_connected:
-            raise RuntimeError("Must connect to device before pairing")
+            await self._client.connect()
 
         await self._send_register()
         # After successful registration, send hello


### PR DESCRIPTION
CosoriKettle's __aenter__ calls connect(), which sends the hello
command (0x81) immediately. During initial pairing this fails with
status 01 because the registration key hasn't been sent yet (0x80).

Fix async_step_pair_device to instantiate CosoriKettle directly and
call pair() manually, which handles connect + register + hello in the
correct order. Update pair() in kettle.py to also handle its own BLE
connection so it is safe to call without going through __aenter__.