### PR TITLE
Add keep warm duration number entity

### DIFF
--- a/custom_components/cosori_kettle_ble/__init__.py
+++ b/custom_components/cosori_kettle_ble/__init__.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,

--- a/custom_components/cosori_kettle_ble/coordinator.py
+++ b/custom_components/cosori_kettle_ble/coordinator.py
@@ -462,6 +462,11 @@ class CosoriKettleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         async with self._lock:
             await self._client.send_set_baby_formula(enabled)
 
+    async def async_set_hold_time(self, seconds: int) -> None:
+        """Set keep warm hold time in seconds (0 disables)."""
+        async with self._lock:
+            await self._client.send_set_hold_time(seconds)
+
     async def async_stop_heating(self) -> None:
         """Stop heating."""
         async with self._lock:

--- a/custom_components/cosori_kettle_ble/number.py
+++ b/custom_components/cosori_kettle_ble/number.py
@@ -1,0 +1,69 @@
+"""Number platform for Cosori Kettle BLE."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import CosoriKettleCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+KEEP_WARM_DURATION = NumberEntityDescription(
+    key="keep_warm_duration",
+    name="Keep Warm Duration",
+    device_class=NumberDeviceClass.DURATION,
+    native_unit_of_measurement=UnitOfTime.MINUTES,
+    native_min_value=0,
+    native_max_value=240,
+    native_step=1,
+    mode=NumberMode.BOX,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    coordinator: CosoriKettleCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([CosoriKettleKeepWarmDuration(coordinator)])
+
+
+class CosoriKettleKeepWarmDuration(CoordinatorEntity[CosoriKettleCoordinator], NumberEntity):
+    """Number entity for keep warm duration."""
+
+    entity_description = KEEP_WARM_DURATION
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: CosoriKettleCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.formatted_address}_keep_warm_duration"
+        self._attr_device_info = coordinator.device_info
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current keep warm duration in minutes."""
+        if not self.coordinator.data:
+            return None
+        seconds = self.coordinator.data.get("configured_hold_time", 0)
+        return round(seconds / 60)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the keep warm duration."""
+        seconds = int(value * 60)
+        await self.coordinator.async_set_hold_time(seconds)
+        await self.coordinator.async_request_refresh()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,95 @@
+"""Tests for the number platform module."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.cosori_kettle_ble.const import DOMAIN
+from custom_components.cosori_kettle_ble.number import CosoriKettleKeepWarmDuration
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock coordinator."""
+    coordinator = AsyncMock()
+    coordinator.data = {
+        "configured_hold_time": 1800,  # 30 minutes in seconds
+    }
+    coordinator.formatted_address = "AA:BB:CC:DD:EE:FF"
+    coordinator.device_info = {
+        "identifiers": {(DOMAIN, "AA:BB:CC:DD:EE:FF")},
+        "name": "Cosori Kettle",
+        "manufacturer": "Cosori",
+        "model": "Smart Kettle",
+    }
+    coordinator.async_set_hold_time = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+@pytest.fixture
+def number_entity(mock_coordinator):
+    """Create a keep warm duration entity."""
+    return CosoriKettleKeepWarmDuration(mock_coordinator)
+
+
+class TestCosoriKettleKeepWarmDurationInit:
+    def test_unique_id(self, number_entity, mock_coordinator):
+        assert number_entity.unique_id == "AA:BB:CC:DD:EE:FF_keep_warm_duration"
+
+    def test_has_entity_name(self, number_entity):
+        assert number_entity.has_entity_name is True
+
+    def test_name(self, number_entity):
+        assert number_entity.name == "Keep Warm Duration"
+
+    def test_min_value(self, number_entity):
+        assert number_entity.native_min_value == 0
+
+    def test_max_value(self, number_entity):
+        assert number_entity.native_max_value == 240
+
+    def test_step(self, number_entity):
+        assert number_entity.native_step == 1
+
+
+class TestCosoriKettleKeepWarmDurationValue:
+    def test_returns_minutes_from_seconds(self, number_entity):
+        # 1800 seconds = 30 minutes
+        assert number_entity.native_value == 30
+
+    def test_returns_zero_when_no_hold_time(self, number_entity, mock_coordinator):
+        mock_coordinator.data["configured_hold_time"] = 0
+        assert number_entity.native_value == 0
+
+    def test_returns_none_when_no_data(self, number_entity, mock_coordinator):
+        mock_coordinator.data = None
+        assert number_entity.native_value is None
+
+    def test_rounds_to_nearest_minute(self, number_entity, mock_coordinator):
+        mock_coordinator.data["configured_hold_time"] = 90  # 1.5 minutes → rounds to 2
+        assert number_entity.native_value == 2
+
+    def test_full_duration(self, number_entity, mock_coordinator):
+        mock_coordinator.data["configured_hold_time"] = 14400  # 240 minutes
+        assert number_entity.native_value == 240
+
+
+class TestCosoriKettleKeepWarmDurationSetValue:
+    @pytest.mark.asyncio
+    async def test_set_value_converts_to_seconds(self, number_entity, mock_coordinator):
+        await number_entity.async_set_native_value(30)
+        mock_coordinator.async_set_hold_time.assert_called_once_with(1800)
+
+    @pytest.mark.asyncio
+    async def test_set_zero_disables(self, number_entity, mock_coordinator):
+        await number_entity.async_set_native_value(0)
+        mock_coordinator.async_set_hold_time.assert_called_once_with(0)
+
+    @pytest.mark.asyncio
+    async def test_requests_refresh_after_set(self, number_entity, mock_coordinator):
+        await number_entity.async_set_native_value(60)
+        mock_coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_240_minutes(self, number_entity, mock_coordinator):
+        await number_entity.async_set_native_value(240)
+        mock_coordinator.async_set_hold_time.assert_called_once_with(14400)


### PR DESCRIPTION
Exposes a settable number entity (0–240 minutes) that reads
configured_hold_time from device status and sends CMD_SET_HOLD_TIME
when the user changes the value.

https://claude.ai/code/session_018P37VBmfHpW441jqfGQqgU